### PR TITLE
[makefile] add explicit call to interpreters on install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,8 +355,8 @@ clear:  clean
 
 install: $(GEN.inst) $(INSTALL.dir)
 	@$(TARGET_VERBOSE)
-	$(GEN.inst) $(INSTALL.dir) \
-	    && $(SRC.pl) --no-warning --tracearg +quit > /dev/null
+	sh $(GEN.inst) $(INSTALL.dir) \
+	    && perl $(SRC.pl) --no-warning --tracearg +quit > /dev/null
 install-f: _INSTALL_FORCE_ = -p
 install-f: install
 


### PR DESCRIPTION
I noticed that the build was failing on my machine because the interpreter call was missing on Makefile.

I'm not sure why this was a problem just for me, I'm building it in a clean environment using sbuild and with the following command:
`make -j8 install DESTDIR=/<<PKGBUILDDIR>>/debian/o-saft AM_UPDATE_INFO_DIR=no "INSTALL=install --strip-program=true"`

Thanks