### PR TITLE
INSTALL.sh: Don't require $TERM or -T to be set on tput

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -478,7 +478,7 @@ all_exe="$osaft_exe $osaft_gui $osaft_sh $osaft_dock $osaft_one"
 
 _line='----------------------+-----------------'
 _cols=0
-\command -v \tput >/dev/null && _cols=`\tput cols`
+\command -v \tput >/dev/null && _cols=$(tput cols || echo "0")
 if [ 0 -lt $_cols ]; then
 	# adapt _line to screen width
 	[ -n "$OSAFT_MAKE" ] && _cols=78    # SEE Make:OSAFT_MAKE


### PR DESCRIPTION
When building the Debian package, $TERM is not set, we also don't care about printing anything, fixes the following error:
```
sh INSTALL.sh debian/o-saft/usr/share/o-saft/
tput: No value for $TERM and no -T specified
INSTALL.sh: 482: [: -lt: argument expected
```

INSTALL.sh already defaults to 0 for number of cols, but it tries to get a number of tput exists.